### PR TITLE
Use https

### DIFF
--- a/src/TransifexApi.js
+++ b/src/TransifexApi.js
@@ -35,7 +35,7 @@ class TransifexApi {
     this.password     = opts.password;
     this.resourceName = opts.resourceName;
 
-    this.baseUrl      = `http://www.transifex.com/api/2/project/${this.projectName}`;
+    this.baseUrl      = `https://www.transifex.com/api/2/project/${this.projectName}`;
   }
 
   /**


### PR DESCRIPTION
I got a 301 redirect from http to https when trying to update a resource, so it seems like transifex enforces https for PUT and POST operations. In any case, it's probably good practice to always use https :)