### PR TITLE
Bump request requirement to a version without a security problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "q": "^1.4.1",
-    "request": "^2.67.0"
+    "request": "^2.68.0"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",


### PR DESCRIPTION
Fixing the "Dependencies: insecure" warning in the readme

https://www.npmjs.com/advisories/309